### PR TITLE
修复 after 伪类的 ie8 bug

### DIFF
--- a/src/ui/css/spriteIconMixin.less
+++ b/src/ui/css/spriteIconMixin.less
@@ -32,7 +32,7 @@
     .relative(@relativePos);
     &:after {
         content: '~"@{img}"';
-        text-indent: -9999px;
+        .hide-text();
         position: absolute;
         .position-vertical(@vertical) when (@vertical = center) {
             top: 50%;


### PR DESCRIPTION
`ie8` 下伪类的 `content` 不变的话不起作用
