### PR TITLE
UE说，以后单位都不带边框和背景

### DIFF
--- a/src/ui/css/esui-flat-theme.less
+++ b/src/ui/css/esui-flat-theme.less
@@ -75,10 +75,8 @@
 @text-box-color : #333;
 @text-box-background: #fff;
 
-// UE说单位统一都不带背景和边框了
-@text-box-hint-background: none;
-@text-box-hint-border: 1px solid transparent;
-@text-box-hint-font-size: 12px;
+@text-box-hint-background: #f7f7f7;
+@text-box-hint-border: @text-box-border;
 
 // 系统自定
 @text-box-border-hover: 1px solid #65cabd;


### PR DESCRIPTION
UE说，以后单位都不带边框和背景，金额单位￥带边框、前置，但是这个并不是单位，只是一种说明。。。会存在￥和‘元/次展现'同时存在的情况，此时‘元/次展现'才是真正的textbox的单位。
