### PR TITLE
解决#89继承自ef/UIView的原型属性不容易拓展的问题

### DIFF
--- a/src/mvc/BaseView.js
+++ b/src/mvc/BaseView.js
@@ -39,8 +39,8 @@ define(
                 function (events, key) {
                     // `uiEvents`对象支持两种方式的事件绑定
                     //
-                    // { "controlId:eventType": functionName }
-                    // { "controlId:eventType": [functionNameA, functionNameB] }
+                    // { 'controlId:eventType': functionName }
+                    // { 'controlId:eventType': [functionNameA, functionNameB] }
                     //
                     // 绑定的事件函数是数组类型时，组装为多个`uiEvents`对象形式传入
                     if (u.isArray(events)) {


### PR DESCRIPTION
1. 增加addUIEvents接口
2. 增加addUIProperties接口
3. 重写基类方法bindEvents和getUIProperties的实现
