### PR TITLE
提取表单提交成功后处理提交结果的逻辑为三个`handler`组件

### DIFF
--- a/src/mvc/FormAction.js
+++ b/src/mvc/FormAction.js
@@ -64,34 +64,26 @@ define(
          * @param {Object} entity 提交成功后返回的实体
          */
         FormAction.prototype.handleSubmitResult = function (entity) {
-            this.notifySubmitSuccess(entity);
-
-            // 默认成功后跳转回列表页
-            var entitySaveEvent = this.fire('entitysave', { entity: entity });
-            var handleFinishEvent = this.fire('handlefinish');
-            if (!entitySaveEvent.isDefaultPrevented()
-                && !handleFinishEvent.isDefaultPrevented()
-            ) {
-                this.redirectAfterSubmit(entity);
+            var handler = this.getSubmitHandler();
+            if (handler && typeof handler.handle === 'function') {
+                handlers.handle(entity, this);
             }
         };
 
         /**
-         * 提示用户表单提交成功
-         *
-         * @param {Object} entity 提交成功后返回的实体
+         * 获取提交结果处理组件
          */
-        FormAction.prototype.notifySubmitSuccess = function (entity) {
+        FormAction.prototype.getSubmitHandler = function () {
+            return this.submitHandler;
         };
 
         /**
-         * 执行提交成功后的跳转操作
+         * 设置提交结果处理组件
          *
-         * @param {Mixed} entity 提交后服务器返回的实体数据
+         * @param {Object} handler 提交结果处理组件
          */
-        FormAction.prototype.redirectAfterSubmit = function (entity) {
-            // 默认返回列表页
-            this.back('/' + this.getEntityName() + '/list');
+        FormAction.prototype.setSubmitHandler = function (handler) {
+            this.submitHandler = handler;
         };
 
         /**

--- a/src/mvc/handler/CompositeSubmitHandler.js
+++ b/src/mvc/handler/CompositeSubmitHandler.js
@@ -1,0 +1,51 @@
+/**
+ * UB RIA Base
+ * Copyright 2014 Baidu Inc. All rights reserved.
+ *
+ * @ignore
+ * @file 表单提交成功后的跳转组件
+ * @author yanghuabei
+ * @date $DATE$
+ */
+define(
+    function (require) {
+        var u = require('underscore');
+
+        /**
+         * @class CompositeSubmitHandler
+         *
+         * 表单提交成功后处理组件的组合
+         */
+        var exports = {};
+
+        /**
+         * 设置子组件
+         *
+         * @param {Object[]} handlers 组件数组
+         */
+        exports.setChildHandlers = function (handlers) {
+            this.childHandlers = handlers;
+        };
+
+        /**
+         * 提交成功处理函数
+         *
+         * @param {Object} entity 提交后服务器端返回的实体信息
+         * @param {er.Action} action 表单Action实例
+         */
+        exports.handle = function (entity, action) {
+            u.each(
+                this.childHandlers,
+                function (handler) {
+                    if (typeof handler.handle === 'function') {
+                        handler.handle(entity, action);
+                    }
+                }
+            );
+        };
+
+        var CompositeSubmitHandler = require('eoo').create(exports);
+
+        return CompositeSubmitHandler;
+    }
+);

--- a/src/mvc/handler/RedirectSubmitHandler.js
+++ b/src/mvc/handler/RedirectSubmitHandler.js
@@ -1,0 +1,79 @@
+/**
+ * UB RIA Base
+ * Copyright 2014 Baidu Inc. All rights reserved.
+ *
+ * @ignore
+ * @file 表单提交成功后的跳转组件
+ * @author yanghuabei
+ * @date $DATE$
+ */
+define(
+    function (require) {
+        var u = require('underscore');
+
+        /**
+         * @class RedirectSubmitHandler
+         *
+         * 表单提交成功后的跳转组件
+         */
+        var exports = {};
+
+        /**
+         * 跳转url模版
+         *
+         * @type {string}
+         */
+        exports.template = '/${entityName}/list';
+
+        /**
+         * 设置组件的url模版
+         *
+         * @param {string} template 跳转url模版
+         */
+        exports.setTemplate = function (template) {
+            this.template = template;
+        };
+
+        /**
+         * 提交成功处理函数
+         *
+         * @param {Object} entity 提交后服务器端返回的实体信息
+         * @param {er.Action} action 表单Action实例
+         */
+        exports.handle = function (entity, action) {
+            var entitySaveEvent = action.fire('entitysave', { entity: entity });
+            var handleFinishEvent = action.fire('handlefinish');
+            if (!entitySaveEvent.isDefaultPrevented()
+                && !handleFinishEvent.isDefaultPrevented()
+            ) {
+                this.redirect(entity, action);
+            }
+        };
+
+        /**
+         * 跳转的方法
+         *
+         * @param {Object} entity 提交后服务器端返回的实体信息
+         * @param {er.Action} action 表单Action实例
+         */
+        exports.redirect = function (entity, action) {
+            var data = this.getData(entity, action);
+            var url = u.template(this.template, data);
+            action.back(url);
+        };
+
+        /**
+         * 获取url模版的数据
+         *
+         * @param {Object} entity 提交后服务器端返回的实体信息
+         * @param {er.Action} action 表单Action实例
+         */
+        exports.getData = function (entity, action) {
+            return { entityName: action.getEntityName() };
+        };
+
+        var RedirectSubmitHandler = require('eoo').create(exports);
+
+        return RedirectSubmitHandler;
+    }
+);

--- a/src/mvc/handler/ToastSubmitHandler.js
+++ b/src/mvc/handler/ToastSubmitHandler.js
@@ -1,0 +1,104 @@
+/**
+ * UB RIA Base
+ * Copyright 2014 Baidu Inc. All rights reserved.
+ *
+ * @ignore
+ * @file 表单提交成功后的toast提醒组件
+ * @author yanghuabei
+ * @date $DATE$
+ */
+define(
+    function (require) {
+        var u = require('underscore');
+        require('esui/Toast');
+
+        /**
+         * @class ToastSubmitHandler
+         *
+         * 表单提交成功后的toast提醒组件
+         */
+        var exports = {};
+
+        /**
+         * toast消息模版
+         *
+         * @type {string}
+         */
+        exports.template = '';
+
+        /**
+         * 设置toast消息模版
+         *
+         * @param {string} template toast消息模版
+         */
+        exports.setTemplate = function (template) {
+            this.template = template;
+        };
+
+        /**
+         * 提交成功处理函数
+         *
+         * @param {Object} entity 提交后服务器端返回的实体信息
+         * @param {er.Action} action 表单Action实例
+         */
+        exports.handle = function (entity, action) {
+            var toast = this.getToastMessage(entity, action);
+            if (toast) {
+                showToast(toast);
+            }
+        };
+
+        /**
+         * 获取表单提交成功后显示的信息
+         *
+         * 默认提示信息为“您[创建|修改]的{实体名称}{name}已经成功保存”
+         *
+         * @param {Object} entity 提交后服务器端返回的实体信息
+         * @param {er.Action} action 表单Action实例
+         * @return {string}
+         */
+        exports.getToastMessage = function (entity, action) {
+            if (this.template == null) {
+                return '';
+            }
+
+            if (this.template) {
+                return u.template(this.template, entity || {});
+            }
+            else {
+                var actionType = action.context.formType === 'update'
+                    ? '修改'
+                    : '创建';
+                return '您' + actionType + '的'
+                    + action.getEntityDescription()
+                    + '[<strong>]' + u.escape(entity.name) + '</strong>]'
+                    + '已经成功保存';
+            }
+        };
+
+        /**
+         * 显示toast提示信息，这个方法会控制一个单例，以免信息叠在一起
+         *
+         * @param {string} content 显示的内容
+         * @param {Object} options 配置
+         * @ignore
+         */
+        function showToast(content, options) {
+            var properties = {
+                content: content,
+                disposeOnHide: true,
+                autoShow: true,
+                duration: 3000
+            };
+
+            u.extend(properties, options);
+
+            var toast = require('esui').create('Toast', properties);
+            toast.show();
+        }
+
+        var ToastSubmitHandler = require('eoo').create(exports);
+
+        return ToastSubmitHandler;
+    }
+);


### PR DESCRIPTION
将`toast`提醒与页面跳转提取为两个`handler`组件`ToastSubmitHander`、`RedirectSubmitHandler`，另外提供一个`CompositeSubmitHandler`，可以通过`CompositeSubmitHandler`将多个handler组合。

`FormAction`提供`setSubmitHandler`接口，`FormAction.prototype.handleSubmitResult`调用`handler`的`handle`方法。
