### PR TITLE
修复pascalize转变输入字符串格式的逻辑

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -77,7 +77,7 @@ define(
          */
         util.pascalize = function (s) {
             s = s + '';
-            if (/^([A-Z]+[\s-\/_])*[A-Z]+$/.test(s)) {
+            if (/^[A-Z\s-\/_]+$/.test(s)) {
                 s = s.toLowerCase();
             }
             s = s.replace(


### PR DESCRIPTION
各个单词全大写，且以规定符号分隔的字符串，所有单词转为全小写
