### PR TITLE
修复控件选择逻辑错误。

### DIFF
--- a/src/ui/TreeRichSelector.js
+++ b/src/ui/TreeRichSelector.js
@@ -470,10 +470,12 @@ define(
 
             if (parentItem) {
                 var brothers = parentItem.node.children || [];
-                var allSelected = true;
-                u.each(brothers, function (brother) {
-                    control.setItemState(brother.id, 'isSelected', false);
-                });
+                var allSelected = !u.find(
+                    brothers,
+                    function (brother) {
+                        return !control.getItemState(brother.id, 'isSelected');
+                    }
+                );
                 selectItem(control, parentId, allSelected);
             }
         }
@@ -671,7 +673,7 @@ define(
                 function (node) {
                     return this.getItemState(node.id, 'isSelected');
                 },
-                this
+                control
             );
 
         }


### PR DESCRIPTION
注释写着 “选的是子节点，判断一下是不是全部选择了，全部选择了，也要勾上父节点”

但是后面代码貌似对不上。
