### PR TITLE
修复子类defaultArgs的设置未set到model的store的问题

### DIFF
--- a/src/mvc/ListModel.js
+++ b/src/mvc/ListModel.js
@@ -105,13 +105,6 @@ export default class ListModel extends BaseModel {
 
     set defaultArgs(value) {
         this[DEFAULT_ARGS] = value;
-    }
-
-    /**
-     * @constructs mvc.ListModel
-     */
-    constructor() {
-        super();
 
         // 把默认参数补上，不然像表格的`orderBy`字段没值表格就不能正确显示
         u.each(
@@ -122,6 +115,13 @@ export default class ListModel extends BaseModel {
                 }
             }
         );
+    }
+
+    /**
+     * @constructs mvc.ListModel
+     */
+    constructor() {
+        super();
 
         this.putDatasource(LIST, 0);
         this.putDatasource(LIST_WITHOUT_KEYWORD_URL, 0);


### PR DESCRIPTION
将`set defaultArgs`到`model.store`的逻辑从构造函数赚到`defaultArgs`的`setter`，不然子类重写的`defaultArgs`不会到`store`中