### PR TITLE
修复多层抽屉时关闭最上层导致所有抽屉关闭的问题

### DIFF
--- a/src/mvc/DetailView.js
+++ b/src/mvc/DetailView.js
@@ -50,7 +50,6 @@ define(
 
             drawerActionPanel.on('action@submitcancel', cancel);
             drawerActionPanel.on('action@back', back);
-            drawerActionPanel.on('action@saveandclose', saveAndClose);
 
             return drawerActionPanel;
         };
@@ -76,16 +75,6 @@ define(
             e.stopPropagation();
             e.preventDefault();
             this.hide();
-        }
-
-        /**
-         * 保留当前数据并退出
-         *
-         * @event
-         * @param {mini-event.Event} e 事件参数
-         */
-        function saveAndClose(e) {
-            e.target.hide();
         }
 
         /**

--- a/src/mvc/FormAction.js
+++ b/src/mvc/FormAction.js
@@ -302,9 +302,6 @@ define(
 
             this.view.on('submit', submit, this);
             this.view.on('cancel', this.cancelEdit, this);
-
-            // 将保留数据并退出的事件代理到上层Action
-            require('mini-event').delegate(this.view, this, 'saveandclose');
         };
 
         /**

--- a/src/mvc/FormView.js
+++ b/src/mvc/FormView.js
@@ -309,7 +309,6 @@ define(
         exports.popDrawerAction = function (options, targetId) {
             var drawerActionPanel = this.$super(arguments);
 
-            drawerActionPanel.on('close', saveAndClose, this);
             drawerActionPanel.on(
                 'action@entitysave',
                 function (e) {
@@ -323,18 +322,6 @@ define(
 
             return drawerActionPanel;
         };
-
-        /**
-         * 返回并告诉上层保留数据并退出
-         *
-         * @event
-         * @fires mvc.FormView#saveandclose
-         * @param {mini-event.Event} e 事件参数
-         */
-        function saveAndClose(e) {
-            e.target.hide();
-            this.fire('saveandclose');
-        }
 
         /**
          * 抽屉内Action提交成功后的事件处理句柄

--- a/src/mvc/ListView.js
+++ b/src/mvc/ListView.js
@@ -456,7 +456,6 @@ define(
 
             drawerActionPanel.on('action@submitcancel', cancel);
             drawerActionPanel.on('action@back', back);
-            drawerActionPanel.on('action@saveandclose', saveAndClose);
             drawerActionPanel.on('close', closeDrawerActionPanel, this);
 
             return drawerActionPanel;
@@ -483,16 +482,6 @@ define(
             e.stopPropagation();
             e.preventDefault();
             this.hide();
-        }
-
-        /**
-         * 保留当前数据并退出
-         *
-         * @event
-         * @param {mini-event.Event} e 事件参数
-         */
-        function saveAndClose(e) {
-            e.target.hide();
         }
 
         /**


### PR DESCRIPTION
删除了触发和监听`saveandclose`事件的代码，MSSP&SSP&galaxy没有依赖这个事件的代码