### PR TITLE
修复多层抽屉时，上层关闭导致下层也被关闭的问题

### DIFF
--- a/src/mvc/FormAction.js
+++ b/src/mvc/FormAction.js
@@ -7,7 +7,6 @@
  */
 
 import oo from 'eoo';
-import event from 'mini-event';
 import {viewEvent} from './decorator';
 import BaseAction from './BaseAction';
 
@@ -222,9 +221,6 @@ export default class FormAction extends BaseAction {
         // 保存一份最初的form表单内容到model，用于判断表单内容是否被更改
         let initialFormData = this.view.getFormData();
         this.model.set('initialFormData', initialFormData, {silent: true});
-
-        // 将保留数据并退出的事件代理到上层Action
-        event.delegate(this.view, this, 'saveandclose');
     }
 
     /**

--- a/src/mvc/FormView.js
+++ b/src/mvc/FormView.js
@@ -247,15 +247,6 @@ export default class FormView extends BaseView {
         let drawerActionPanel = super.popDrawerAction(options);
 
         drawerActionPanel.on(
-            'close',
-            (e) => {
-                e.target.hide();
-                this.fire('saveandclose');
-            }
-        );
-
-
-        drawerActionPanel.on(
             'action@entitysave',
             (e) => {
                 e.stopPropagation();

--- a/src/mvc/ListView.js
+++ b/src/mvc/ListView.js
@@ -357,7 +357,6 @@ export default class ListView extends BaseView {
                 e.target.hide();
             }
         );
-        drawerActionPanel.on('action@saveandclose', (e) => e.target.hide());
         drawerActionPanel.on('close', () => this.fire('close'));
 
         return drawerActionPanel;


### PR DESCRIPTION
删除了触发和监听`saveandclose`事件的代码，galaxy没有依赖这个事件的代码.